### PR TITLE
Special fixes

### DIFF
--- a/mparray/special/_special.py
+++ b/mparray/special/_special.py
@@ -121,20 +121,30 @@ def expit(x):  # needs accuracy review
     return mp.exp(x - mp.log1p(mp.exp(x)))
 
 
-@vectorize
-def boxcox(x, lmbda):  # needs accuracy review
+def _boxcox_scalar(x, lmbda):
     """
     y = (x**lmbda - 1) / lmbda  if lmbda != 0
         log(x)                  if lmbda == 0
     """
+    if x < 0:
+        return mp.nan
     if lmbda != 0:
         return mp.powm1(x, lmbda) / lmbda
     else:
-        return mp.lmbda(x)
+        return mp.log(x)
 
 
-def boxcox1p(x, lmbda):  # needs accuracy review
-    return boxcox(mp.one + x, lmbda)
+@vectorize
+def boxcox(x, lmbda):
+    return _boxcox_scalar(x, lmbda)
+
+
+def boxcox1p(x, lmbda):
+    if x < - 1:
+        return mp.nan
+    extra_dps = max(0, int(mp.ceil(-mp.log10(abs(x)))))
+    with mp.workdps(mp.dps + extra_dps):
+        return _boxcox_scalar(mp.one + x, lmbda)
 
 
 def logsumexp(a, axis=None, b=None):

--- a/mparray/special/_special.py
+++ b/mparray/special/_special.py
@@ -70,10 +70,6 @@ def betaln(x, y):
 
 @vectorize
 def betainc(a, b, x):
-    if x < 0 or x > 1:
-        # The mpmath betainc implementation is defined on entire real line,
-        # (and the complex plane). We want to match scipy.special.betainc.
-        return mp.nan
     return mp.betainc(a, b, 0, x, regularized=True)
 
 
@@ -99,8 +95,6 @@ def xlog1py(x, y):  # needs accuracy review
 
 @vectorize
 def cosm1(x):
-    if x == 0:
-        return mp.zero
     # second term in cosine series is x**2/2
     # catastrophic cancellation also occurs near nonzero multiples of 2*pi,
     # but doubling precision is enough here. We are being conservative by

--- a/mparray/special/_special.py
+++ b/mparray/special/_special.py
@@ -42,6 +42,13 @@ def gammaincc(a, x):
 
 @vectorize
 def ndtri(x):
+    if x == 0:
+        return -mp.inf
+    if x == 1:
+        return mp.inf
+    if x < 0 or x > 1:
+        return mp.nan
+
     extra_dps = int(mp.ceil(-mp.log10(x)))
     mp.dps += extra_dps
     res = mp.sqrt(2) * mp.erfinv(2 * x - mp.one)

--- a/mparray/special/_special.py
+++ b/mparray/special/_special.py
@@ -95,6 +95,9 @@ def xlog1py(x, y):  # needs accuracy review
 
 @vectorize
 def cosm1(x):
+    if x == 0:
+        # Handle this case separately to avoid blow up in extra_dps calculation.
+        return mp.zero
     # second term in cosine series is x**2/2
     # catastrophic cancellation also occurs near nonzero multiples of 2*pi,
     # but doubling precision is enough here. We are being conservative by

--- a/mparray/special/_special.py
+++ b/mparray/special/_special.py
@@ -50,10 +50,8 @@ def ndtri(x):
         return mp.nan
 
     extra_dps = int(mp.ceil(-mp.log10(x)))
-    mp.dps += extra_dps
-    res = mp.sqrt(2) * mp.erfinv(2 * x - mp.one)
-    mp.dps -= extra_dps
-    return res
+    with mp.workdps(mp.dps + extra_dps):
+        return mp.sqrt(2) * mp.erfinv(2 * x - mp.one)
 
 
 @vectorize

--- a/mparray/special/_special.py
+++ b/mparray/special/_special.py
@@ -99,12 +99,15 @@ def xlog1py(x, y):  # needs accuracy review
 
 @vectorize
 def cosm1(x):
+    if x == 0:
+        return mp.zero
     # second term in cosine series is x**2/2
-    extra_dps = 2*int(mp.ceil(-mp.log10(x))) + 1
-    mp.dps += extra_dps
-    res = mp.cos(x) - mp.one
-    mp.dps -= extra_dps
-    return res
+    # catastrophic cancellation also occurs near nonzero multiples of 2*pi,
+    # but doubling precision is enough here. We are being conservative by
+    # always at least doubling the precision.
+    extra_dps = max(mp.dps, 2*int(mp.ceil(-mp.log10(x))) + 1)
+    with mp.workdps(mp.dps + extra_dps):
+        return mp.cos(x) - mp.one
 
 
 @vectorize

--- a/mparray/special/_special.py
+++ b/mparray/special/_special.py
@@ -136,9 +136,11 @@ def boxcox(x, lmbda):
     return _boxcox_scalar(x, lmbda)
 
 
+@vectorize
 def boxcox1p(x, lmbda):
-    if x < - 1:
-        return mp.nan
+    if x == 0:
+        # Handle x = 0 separately to avoid blow up in extra_dps calculation.
+        return mp.zero
     extra_dps = max(0, int(mp.ceil(-mp.log10(abs(x)))))
     with mp.workdps(mp.dps + extra_dps):
         return _boxcox_scalar(mp.one + x, lmbda)

--- a/mparray/special/_special.py
+++ b/mparray/special/_special.py
@@ -70,6 +70,10 @@ def betaln(x, y):
 
 @vectorize
 def betainc(a, b, x):
+    if x < 0 or x > 1:
+        # The mpmath betainc implementation is defined on entire real line,
+        # (and the complex plane). We want to match scipy.special.betainc.
+        return mp.nan
     return mp.betainc(a, b, 0, x, regularized=True)
 
 

--- a/mparray/special/_special.py
+++ b/mparray/special/_special.py
@@ -31,13 +31,13 @@ kv = vectorize(mp.besselk)
 
 
 @vectorize
-def gammainc(x, a):
-    return mp.gammainc(x, a=0, b=a, regularized=True)
+def gammainc(a, x):
+    return mp.gammainc(a, a=0, b=x, regularized=True)
 
 
 @vectorize
-def gammaincc(x, a):
-    return mp.gammainc(x, a=a, b=mp.inf, regularized=True)
+def gammaincc(a, x):
+    return mp.gammainc(a, a=x, b=mp.inf, regularized=True)
 
 
 @vectorize


### PR DESCRIPTION
This PR makes a few small fixes to the special functions that currently exist in mparray. 

The fixes here are:

1. Change the signature of `mparray.gamminc` to match that of `scipy.special.gammainc`. That of `mparray.gammainc` is currently `gammainc(x, a)` and that of `scipy.special.gammainc` is `gamma(a, x)`, where the meaning of `x` and `a` is swapped. This was an easy mixup to make because `mparray` currently follows `mpmath` which also gives the opposite meanings to these variable names compared to SciPy. I think the variable names in `mpmath` are just an implementation detail.
2. Handle boundary and out of bounds cases in `ndtri`. It currently errors out for `x = 0` and for `x < 0 or x > 1`. It should return `-inf` and `nan` respectively in these cases.
3. Handle out of bounds cases in `betainc`.
4. Fix bug in `cosm1` causing negative `extra_dps` for large `x`.
5. Make `cosm1` handle catastrophic cancellation near nonzero integer multiples of $2\pi$.
6. Fix typo in `boxcox`, `mp.lmbda(x)` which should have been `mp.log(x)`.
7. Handle out of bounds cases for `boxcox` and `boxcox1p`.
8. Fix precision issues for `boxcox1p` near `x = 0`, by setting higher working dps when needed.

I've also changed increases of working dps to use the `mp.workdps` context manager.

There will be followups to add more functions which already exist in mpmath, and to implement more functions which do not currently exist in mpmath.